### PR TITLE
Detecting only URLs with domains, using HEAD method

### DIFF
--- a/linkcheckmd/base.py
+++ b/linkcheckmd/base.py
@@ -12,7 +12,7 @@ def run_check(
     if domain:
         pat = "https?://" + domain + r"[=a-zA-Z0-9\_\/\?\&\%\+\#\.\-]*"
     else:
-        pat = r"https?://[=a-zA-Z0-9\_\/\?\&\%\+\#\.\-]*"
+        pat = r"https?://[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.[=a-zA-Z0-9\_\/\?\&\%\+\#\.\-]+"
 
     if ext == ".md":
         pat = r"\(" + pat + r"\)"

--- a/linkcheckmd/coro.py
+++ b/linkcheckmd/coro.py
@@ -43,7 +43,7 @@ async def check_url(
         if ext == ".md":
             url = url[1:-1]
         try:
-            R = await requests.get(url, allow_redirects=True, timeout=TIMEOUT, headers=hdr, verify_ssl=False)
+            R = await requests.head(url, allow_redirects=True, timeout=TIMEOUT, headers=hdr, verify_ssl=False)
         except OKE:
             continue
         except EXC as e:

--- a/linkcheckmd/sync.py
+++ b/linkcheckmd/sync.py
@@ -87,7 +87,7 @@ def retry(url: str, hdr: typing.Dict[str, str] = None, verifycert: bool = False)
     ok = False
 
     try:
-        with requests.get(url, allow_redirects=True, timeout=TIMEOUT, verify=verifycert, headers=hdr, stream=True) as stream:
+        with requests.head(url, allow_redirects=True, timeout=TIMEOUT, verify=verifycert, headers=hdr, stream=True) as stream:
             Rb = next(stream.iter_lines(80), None)
             # if Rb is not None and 'html' in Rb.decode('utf8'):
             if Rb and len(Rb) > 10:


### PR DESCRIPTION
Fixes #4
Fixes issue with ["https://"](https://github.com/coreinfrastructure/best-practices-badge/blob/3d1da0dc0c274598d6dbae5417e356a7bbd2486a/config/locales/en.yml#L413) being detected as URL
