### PR TITLE
Add argparse option to pass custom headers

### DIFF
--- a/src/linkcheckmd/__main__.py
+++ b/src/linkcheckmd/__main__.py
@@ -30,7 +30,7 @@ def main():
         help="head is faster but gives false positives. Get is reliable but slower",
         default="get",
     )
-    p.add_argument("-h", "--headers", help="add custom headers dictionary", type=json.loads)
+    p.add_argument("--headers", help="add custom headers dictionary", type=json.loads)
     p.add_argument("-v", "--verbose", action="store_true")
     p.add_argument("--sync", help="don't use asyncio", action="store_true")
     p.add_argument("-local", help="only check local files", action="store_true")

--- a/src/linkcheckmd/__main__.py
+++ b/src/linkcheckmd/__main__.py
@@ -9,6 +9,7 @@ linkcheckMarkdown ~/myJekyllsite/_posts
 import argparse
 import logging
 import time
+import json
 
 from .base import check_links
 
@@ -29,6 +30,7 @@ def main():
         help="head is faster but gives false positives. Get is reliable but slower",
         default="get",
     )
+    p.add_argument("-h", "--headers", help="add custom headers dictionary", type=json.loads)
     p.add_argument("-v", "--verbose", action="store_true")
     p.add_argument("--sync", help="don't use asyncio", action="store_true")
     p.add_argument("-local", help="only check local files", action="store_true")
@@ -44,6 +46,7 @@ def main():
         ext=P.ext,
         domain=P.domain,
         method=P.method,
+        hdr=P.headers,
         use_async=not P.sync,
         local=P.local,
         recurse=P.recurse,


### PR DESCRIPTION
Hi, this is a very nice tool! 

 I'm trying to use this in some docs of my organizations but we have some private repo where we will need to pass some credentials with headers, I notice there is the option in the `core` but not in the argparse... This PR should add it.
Let me know what do you think... 
 
P. S. 
Hey, don't want to bother but can I suggest putting some lines about contributing? A requirements.txt or maybe switch to [poetry](https://python-poetry.org/) package manager :) 