### PR TITLE
Add relative path determination and update error output

### DIFF
--- a/src/linkcheckmd/coro.py
+++ b/src/linkcheckmd/coro.py
@@ -6,6 +6,7 @@ import warnings
 import asyncio
 import itertools
 import logging
+import os
 
 import aiohttp
 
@@ -13,6 +14,7 @@ from . import files
 
 # tuples, not lists
 
+CWD = os.getcwd()
 EXC = (
     aiohttp.client_exceptions.ClientConnectorError,
     aiohttp.client_exceptions.ServerDisconnectedError,
@@ -56,6 +58,7 @@ async def check_url(
     bad: list[tuple[str, str, T.Any]] = []
 
     timeout = aiohttp.ClientTimeout(total=TIMEOUT)
+    rel_path = os.path.relpath(os.path.abspath(str(fn)), start=os.path.abspath(CWD))
 
     for url in urls:
         if ext == ".md":
@@ -74,13 +77,13 @@ async def check_url(
         except OKE:
             continue
         except EXC as e:
-            bad.append((fn.name, url, e))  # e, not str(e)
-            print("\n", bad[-1])
+            bad.append((str(fn), url, e))  # e, not str(e)
+            print(f"ERROR: '{rel_path}' '{url}' '{e}'")
             continue
 
         if code != 200:
-            bad.append((fn.name, url, code))
-            print("\n", bad[-1])
+            bad.append((str(fn), url, code))
+            print(f"ERROR: '{rel_path}' '{url}' {code}")
         else:
             logging.info(f"OK: {url:80s}")
 

--- a/src/linkcheckmd/coro.py
+++ b/src/linkcheckmd/coro.py
@@ -14,7 +14,7 @@ from . import files
 
 # tuples, not lists
 
-CWD = os.getcwd()
+CWD = os.path.abspath(os.getcwd())
 EXC = (
     aiohttp.client_exceptions.ClientConnectorError,
     aiohttp.client_exceptions.ServerDisconnectedError,
@@ -58,7 +58,7 @@ async def check_url(
     bad: list[tuple[str, str, T.Any]] = []
 
     timeout = aiohttp.ClientTimeout(total=TIMEOUT)
-    rel_path = os.path.relpath(os.path.abspath(str(fn)), start=os.path.abspath(CWD))
+    rel_path = os.path.relpath(os.path.abspath(str(fn)), start=CWD)
 
     for url in urls:
         if ext == ".md":


### PR DESCRIPTION
## Description

- Fixes #16 
- Add relative path determination and update error output
- I'm happy to change formatting / structure of error output, just let me know.

## Output

The example below includes only a single file, for brevity. If the entire project was scanned, there would be many more errors, but the old output would not indicate which file (all files are named `contents.lr`).

### New Output
Command:
```shell
linkcheckMarkdown -ext .lr content/archives/old-tech-blog/entries/issue-tracking-at-codecreativecommonsorg/
```
Output:
```
ERROR: 'content/archives/old-tech-blog/entries/issue-tracking-at-codecreativecommonsorg/contents.lr' 'http://code.creativecommons.org/issues' 404
ERROR: 'content/archives/old-tech-blog/entries/issue-tracking-at-codecreativecommonsorg/contents.lr' 'http://learn.creativecommons.org/projects/oesearch' 'Cannot connect to host learn.creativecommons.org:80 ssl:default [nodename nor servname provided, or not known]'
ERROR: 'content/archives/old-tech-blog/entries/issue-tracking-at-codecreativecommonsorg/contents.lr' 'http://code.creativecommons.org/issues/issue7' 404
4.58 seconds to check links
```

### Old Output
Command:
```shell
linkcheckMarkdown -ext .lr content/archives/old-tech-blog/entries/issue-tracking-at-codecreativecommonsorg/
```
Output:
```

 ('contents.lr', 'http://code.creativecommons.org/issues', 404)

 ('contents.lr', 'http://learn.creativecommons.org/projects/oesearch', ClientConnectorError(ConnectionKey(host='learn.creativecommons.org', port=80, is_ssl=False, ssl=None, proxy=None, proxy_auth=None, proxy_headers_hash=-5849311230535720466), gaierror(8, 'nodename nor servname provided, or not known')))

 ('contents.lr', 'http://code.creativecommons.org/issues/issue7', 404)
4.65 seconds to check links
```
