### PR TITLE
Smallest possible change to ignore SSL certs

### DIFF
--- a/src/linkcheckmd/coro.py
+++ b/src/linkcheckmd/coro.py
@@ -62,7 +62,9 @@ async def check_url(
             url = url[1:-1]
         try:
             # anti-crawling behavior doesn't like .head() method--.get() is slower but avoids lots of false positives
-            async with aiohttp.ClientSession(headers=hdr, timeout=timeout) as session:
+            async with aiohttp.ClientSession(headers=hdr,
+                                             timeout=timeout,
+                                             connector=aiohttp.TCPConnector(ssl=False)) as session:
                 if method == "get":
                     async with session.get(url, allow_redirects=True) as response:
                         code = response.status


### PR DESCRIPTION
I tested this with

```bash
pipenv install "linkcheckmd @ git+https://github.com/matthewdeanmartin/linkchecker-markdown@b05bac0c852a5f5c0e92a4836d522210daef6823"
```

I figured making this a command line option would be more intrusive & take you longer to review, so I went the minimal route in hopes of a quick merge & publish to pypi.

Thanks for writing this tool.