### PR TITLE
Add exclusion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,406 +1,130 @@
-# LinkCheckMD - Markdown Link Checker
+# Linkchecker for Markdown
 
 [![ci](https://github.com/scivision/linkchecker-markdown/actions/workflows/ci.yml/badge.svg)](https://github.com/scivision/linkchecker-markdown/actions/workflows/ci.yml)
 [![PyPI Download stats](http://pepy.tech/badge/linkcheckmd)](http://pepy.tech/project/linkcheckmd)
 
-> **Note**: This is a fork of [scivision/linkchecker-markdown](https://github.com/scivision/linkchecker-markdown) with additional domain exclusion functionality. All credit for the original implementation goes to the original maintainers.
+Blazing-fast (10000 Markdown files per second) Python asyncio using the high-level
+[aiohttp](https://docs.aiohttp.org/)
+library.
+Simple check of links in Markdown .md files only.
+This tool is very helpful for statically generated Markdown-based sites (e.g. Jekyll and Hugo).
+Markdown-based
+[MkDocs](https://www.mkdocs.org/)
+documentation projects can also benefit.
 
-A blazing-fast Python tool for checking links in Markdown files. Capable of processing 10,000+ Markdown files per second using high-performance asyncio and the [aiohttp](https://docs.aiohttp.org/) library.
+## Install
 
-**LinkCheckMD** is specifically designed for Markdown-based static site generators like Jekyll, Hugo, and MkDocs, providing fast and reliable link validation for documentation projects and static websites.
+for latest release:
 
-## Features
-
-- ⚡ **Ultra-fast**: Asynchronous processing with configurable concurrency
-- 🔗 **Comprehensive**: Checks both local and remote links
-- 🎯 **Selective**: Filter by domain or exclude specific domains *(NEW in this fork)*
-- 🛡️ **Robust**: Handles SSL verification, custom headers, and retry logic
-- 📊 **Detailed**: Verbose output with timing information
-- 🚀 **CI-ready**: Perfect for continuous integration pipelines
-- 🔧 **Flexible**: Both Python API and command-line interface
-
-## Installation
-
-### Latest Release (PyPI)
-```bash
-pip install linkcheckmd
+```sh
+python -m pip install linkcheckmd
 ```
 
-### Development Version
-```bash
+or for latest development version.
+
+```sh
 git clone https://github.com/scivision/linkchecker-markdown
+
 pip install -e ./linkchecker-markdown
 ```
 
-## Quick Start
+## Usage
 
-### Command Line Usage
-```bash
-# Check all markdown files in current directory
-python -m linkcheckmd .
+The static site generator does NOT have to be running for these tests.
+This program looks at the Markdown .md files directly.
 
-# Check specific directory recursively
-python -m linkcheckmd -r ./docs
+If any local or remote links are determined to be missing, the following happens:
 
-# Exclude problematic domains
+* the file containing the bad link and the link is printed to "stdout"
+* the program will exit with code 22 instead of 0 after all files are checked
+
+The bad links are printed to stdout since the normal operation of this program is to check for errors.
+Due to the fast, concurrent checking and numerous pages checked, there may be diagnostics printed to stderr.
+That way library error messages can be kept separate from the missing page locations printed on stdout.
+
+
+The examples assume webpage Markdown files have top-level directory ~/web.
+*If using the linkchecker on an MkDocs documentation project, Markdown files
+are typically found in a `~/docs` directory.*
+
+### Python code
+
+```python
+import linkcheckmd as lc
+
+lc.check_links("~/web")
+```
+
+### Command-line
+
+This program may be invoked:
+
+```sh
+python -m linkcheckmd
+```
+
+* Jekyll
+
+    ```sh
+    python -m linkcheckmd ~/web/_posts
+    ```
+
+* Hugo
+
+    ```sh
+    python -m linkcheckmd ~/web/content
+    ```
+
+* MkDocs Documentation
+
+    ```sh
+    python -m linkcheckmd ~/docs
+    ```
+
+* Exclude domains from checking
+
+```sh
 python -m linkcheckmd -r ./docs -e example.com -e slow-site.org
-
-# Check only local files (skip remote URLs)
-python -m linkcheckmd -local ./docs
 ```
 
-### Python API
-```python
-import linkcheckmd as lc
+The `-e, --exclude` option allows specifying one or more domains to exclude from link checking. This is useful to skip known problematic sites, internal services, or slow external domains. Multiple `-e` options can be used to build the exclusion list.
 
-# Basic usage
-bad_links = lc.check_links("./docs")
+Observe that URLs from different markdown files are interleaved, showing the asynchronous nature of this program.
 
-# With domain exclusion
-bad_links = lc.check_links("./docs", exclude_domains=["example.com", "test.org"])
-
-# Local files only
-local_issues = lc.check_local("./docs", ext=".md")
+```markdown
+# Example usage excluding domains:
+python -m linkcheckmd -r ./docs -e example.com -e slow-site.org -e slow-external-site.com
 ```
 
-## Command Line Arguments
+The `-v` `--verbose` options prints the URLs as they are checked.
+Observe that URLs from different markdown files are interleaved, showing the asynchronous nature of this program.
 
-### Required Arguments
+### Benchmark
 
-| Argument | Description | Example |
-|----------|-------------|---------|
-| `path` | Path to Markdown files | `./docs`, `~/website/content` |
+For benchmarking and reference, we include a synchronous Requests-based method.
+For a website with 100+ pages, compare times of:
 
-### Optional Arguments
+### Git precommit
 
-| Argument | Description | Default | Example |
-|----------|-------------|---------|---------|
-| `domain` | Check only links to specific domain | None | `github.com` |
-| `-ext` | File extension to scan | `.md` | `-ext .markdown` |
-| `-m, --method` | HTTP method (get/head) | `get` | `--method head` |
-| `--headers` | Custom HTTP headers (JSON) | None | `--headers '{"User-Agent": "MyBot"}'` |
-| `-v, --verbose` | Enable verbose output | False | `-v` |
-| `--sync` | Use synchronous requests | False | `--sync` |
-| `-local` | Check only local files | False | `-local` |
-| `-r, --recurse` | Recurse subdirectories | False | `-r` |
-| `-noverify` | Skip SSL certificate verification | False | `-noverify` |
-| `-e, --exclude` | Exclude domains from checking | [] | `-e hashicorp.com -e terraform.io` |
+See
+[./examples/pre-commit](./examples/pre-commit)
+script for a
+[Git hook pre-commit](https://www.scivision.dev/git-markdown-pre-commit-linkcheck)
+Python script.
 
-## Detailed Usage Examples
+### Tox and CI
 
-### Basic Link Checking
-
-```bash
-# Check current directory
-python -m linkcheckmd .
-
-# Check specific directory
-python -m linkcheckmd ./documentation
-
-# Check with verbose output
-python -m linkcheckmd -v ./docs
-```
-
-### Static Site Generators
-
-```bash
-# Jekyll
-python -m linkcheckmd ~/website/_posts
-
-# Hugo
-python -m linkcheckmd ~/website/content
-
-# MkDocs
-python -m linkcheckmd ~/docs
-
-# GitBook
-python -m linkcheckmd ~/gitbook
-```
-
-### Domain Filtering
-
-```bash
-# Check only GitHub links
-python -m linkcheckmd ./docs github.com
-
-# Exclude multiple domains
-python -m linkcheckmd -r ./docs -e hashicorp.com -e terraform.io -e slow-external-site.com
-
-# Exclude domains with subdomains
-python -m linkcheckmd ./docs -e reddit.com  # Excludes www.reddit.com, old.reddit.com, etc.
-```
-
-### Advanced Options
-
-```bash
-# Use HEAD requests for faster checking (may have false positives)
-python -m linkcheckmd --method head ./docs
-
-# Custom headers for sites requiring authentication
-python -m linkcheckmd --headers '{"Authorization": "Bearer token123"}' ./docs
-
-# Skip SSL verification for internal sites
-python -m linkcheckmd -noverify ./internal-docs
-
-# Use synchronous checking (slower but more predictable)
-python -m linkcheckmd --sync ./docs
-```
-
-### Local File Checking Only
-
-```bash
-# Check only internal links (skip all HTTP/HTTPS)
-python -m linkcheckmd -local ./docs
-
-# Useful for offline development or testing internal structure
-python -m linkcheckmd -local -r ./entire-project
-```
-
-## Domain Exclusion Feature
-
-The `-e, --exclude` option allows you to skip link checking for specific domains. This is particularly useful for:
-
-- **Known problematic sites**: Domains with anti-bot protection or rate limiting
-- **Internal services**: Private or development domains not accessible during CI
-- **Third-party dependencies**: External services outside your control
-- **Performance optimization**: Skip slow or unreliable domains
-
-### How It Works
-
-Domain exclusion performs case-insensitive substring matching:
-
-```bash
-# This command
-python -m linkcheckmd -e example.com ./docs
-
-# Will skip these URLs:
-# https://example.com/page
-# https://www.example.com/api
-# https://api.example.com/v1/data
-# http://blog.example.com/post/123
-```
-
-### CI/CD Integration Examples
-
-#### GitLab CI
-```yaml
-check-links:
-  stage: test
-  script:
-    - pip install linkcheckmd
-    - python -m linkcheckmd -r ./docs -e hashicorp.com -e terraform.io
-  rules:
-    - if: $CI_MERGE_REQUEST_IID
-```
-
-#### GitHub Actions
-```yaml
-- name: Check Links
-  run: |
-    pip install linkcheckmd
-    python -m linkcheckmd -r ./docs -e internal.company.com -e staging.example.org
-```
-
-#### Jenkins
-```groovy
-stage('Link Check') {
-    steps {
-        sh 'pip install linkcheckmd'
-        sh 'python -m linkcheckmd -r ./docs -e dev.example.com'
-    }
-}
-```
-
-## Python API Reference
-
-### Core Functions
-
-#### `check_links(path, domain=None, **kwargs)`
-Main function that checks both local and remote links.
-
-**Parameters:**
-- `path` (Path): Directory containing Markdown files
-- `domain` (str, optional): Check only links to this domain
-- `ext` (str): File extension to scan (default: ".md")
-- `hdr` (dict, optional): Custom HTTP headers
-- `method` (str): HTTP method - "get" or "head" (default: "get")
-- `use_async` (bool): Use async processing (default: True)
-- `local` (bool): Check only local files (default: False)
-- `recurse` (bool): Recurse subdirectories (default: False)
-- `ssl_verify` (bool): Verify SSL certificates (default: True)
-- `exclude_domains` (list, optional): Domains to exclude from checking
-
-**Returns:** List of bad links as tuples (file_path, url, error)
-
-#### `check_local(path, ext=".md")`
-Check only local/internal links within Markdown files.
-
-**Parameters:**
-- `path` (Path): Directory to scan
-- `ext` (str): File extension to check
-
-**Returns:** Generator of tuples (file_path, problematic_url)
-
-#### `check_remotes(path, domain=None, **kwargs)`
-Check only remote HTTP/HTTPS links.
-
-**Parameters:** Same as `check_links()` but focuses on remote URLs only.
-
-**Returns:** List of bad remote links
-
-### Example Usage
-
-```python
-import linkcheckmd as lc
-from pathlib import Path
-
-# Basic check
-docs_path = Path("./documentation")
-issues = lc.check_links(docs_path)
-
-# Advanced configuration
-issues = lc.check_links(
-    docs_path,
-    exclude_domains=["internal.company.com", "dev.example.org"],
-    method="head",  # Faster but less reliable
-    ssl_verify=False,  # For internal sites
-    recurse=True,  # Check subdirectories
-    hdr={"User-Agent": "LinkChecker/1.0"}  # Custom headers
-)
-
-# Handle results
-for file_path, url, error in issues:
-    print(f"❌ {file_path}: {url} - {error}")
-
-# Check only local links
-local_issues = list(lc.check_local(docs_path))
-for file_path, url in local_issues:
-    print(f"🔗 Local link issue in {file_path}: {url}")
-```
-
-## Exit Codes
-
-LinkCheckMD follows standard Unix conventions:
-
-- **0**: Success - all links are valid
-- **22**: Error - one or more links are broken (follows cURL convention)
-
-This makes it perfect for CI/CD pipelines where you want builds to fail on broken links.
-
-## Performance and Behavior
-
-### Asynchronous Processing
-- Uses `aiohttp` for concurrent HTTP requests
-- Configurable timeout (10 seconds default)
-- Automatic retry logic for transient failures
-- Memory-efficient streaming for large sites
-
-### Error Handling
-- Distinguishes between network errors and HTTP errors
-- Handles redirects automatically
-- Graceful handling of SSL certificate issues
-- Comprehensive logging with `-v` flag
-
-### Output Format
-- **stdout**: Broken links (for easy parsing)
-- **stderr**: Debug information and warnings
-- **Timing**: Execution time printed at completion
-
-## Common Use Cases
-
-### Documentation Teams
-```bash
-# Daily documentation health check
-python -m linkcheckmd -r ./docs -e internal.company.com > broken-links.txt
-```
-
-### DevOps Integration
-```bash
-# Pre-deployment link validation
-python -m linkcheckmd -r ./site-content -e staging.example.com -e dev.example.com
-```
-
-### Content Migration
-```bash
-# Check content after migration, excluding old domains
-python -m linkcheckmd ./migrated-content -e old-site.com -e legacy.example.org
-```
-
-### Development Workflow
-```bash
-# Quick local check during development
-python -m linkcheckmd -local ./docs  # Skip external links
-```
-
-## Troubleshooting
-
-### Common Issues
-
-**False Positives with HEAD Requests:**
-```bash
-# Solution: Use GET method (slower but more reliable)
-python -m linkcheckmd --method get ./docs
-```
-
-**SSL Certificate Errors:**
-```bash
-# Solution: Disable SSL verification
-python -m linkcheckmd -noverify ./docs
-```
-
-**Rate Limiting:**
-```bash
-# Solution: Exclude problematic domains
-python -m linkcheckmd -e rate-limited-site.com ./docs
-```
-
-**Slow External Sites:**
-```bash
-# Solution: Use domain exclusion
-python -m linkcheckmd -e slow-site.org -e another-slow-site.com ./docs
-```
-
-### Debugging
-
-Enable verbose output to see what's happening:
-```bash
-python -m linkcheckmd -v ./docs
-```
-
-This shows:
-- URLs being checked in real-time
-- Success confirmations
-- Detailed error messages
-- Performance timing
+This program can also be used as a check for bad links during continuous integration
+testing or when using [`tox`](https://tox.readthedocs.io/).
 
 ## Alternatives
 
-While LinkCheckMD is optimized for Markdown files, consider these alternatives for different use cases:
+Strict anti-leeching methods can cause false positives with this and other link checking programs.
 
-- **[htmltest](https://github.com/wjdp/htmltest)**: Go-based, works with HTML files
-- **[GitHub Action](https://github.com/marketplace/actions/markdown-link-check)**: For GitHub-hosted projects
-- **[Netlify Plugin](https://github.com/munter/netlify-plugin-checklinks)**: For Netlify deployments
-- **Browser-based tools**: For JavaScript-heavy sites requiring full rendering
+Alternative solutions include:
 
-## Contributing
-
-This fork adds domain exclusion functionality to the original [scivision/linkchecker-markdown](https://github.com/scivision/linkchecker-markdown) project. 
-
-For contributions to the core functionality, please consider contributing to the upstream project. For issues or improvements specific to the domain exclusion feature, contributions are welcome!
-
-Areas for improvement:
-
-- Additional output formats (JSON, XML)
-- Better regex patterns for edge cases
-- Performance optimizations
-- Additional authentication methods
-- Support for more file formats
-
-## Credits
-
-- **Original Project**: [scivision/linkchecker-markdown](https://github.com/scivision/linkchecker-markdown)
-- **Domain Exclusion Feature**: Added in this fork for CI/CD workflows that need to skip specific domains
-
-## License
-
-See [LICENSE.txt](LICENSE.txt) for details.
+* asyncio-based web browser interface like Arsenic
+* Go-based [htmltest](https://github.com/wjdp/htmltest).
+* [GitHub Action](https://github.com/marketplace/actions/markdown-link-check) for checking links in Markdown files.
+* Netlify link-check [plugin](https://github.com/munter/netlify-plugin-checklinks#readme)
+* LinkChecker.py: too many false positives/negatives, very slow and only works with HTML.

--- a/README.md
+++ b/README.md
@@ -1,115 +1,406 @@
-# Linkchecker for Markdown
+# LinkCheckMD - Markdown Link Checker
 
 [![ci](https://github.com/scivision/linkchecker-markdown/actions/workflows/ci.yml/badge.svg)](https://github.com/scivision/linkchecker-markdown/actions/workflows/ci.yml)
 [![PyPI Download stats](http://pepy.tech/badge/linkcheckmd)](http://pepy.tech/project/linkcheckmd)
 
-Blazing-fast (10000 Markdown files per second) Python asyncio using the high-level
-[aiohttp](https://docs.aiohttp.org/)
-library.
-Simple check of links in Markdown .md files only.
-This tool is very helpful for statically generated Markdown-based sites (e.g. Jekyll and Hugo).
-Markdown-based
-[MkDocs](https://www.mkdocs.org/)
-documentation projects can also benefit.
+> **Note**: This is a fork of [scivision/linkchecker-markdown](https://github.com/scivision/linkchecker-markdown) with additional domain exclusion functionality. All credit for the original implementation goes to the original maintainers.
 
-## Install
+A blazing-fast Python tool for checking links in Markdown files. Capable of processing 10,000+ Markdown files per second using high-performance asyncio and the [aiohttp](https://docs.aiohttp.org/) library.
 
-for latest release:
+**LinkCheckMD** is specifically designed for Markdown-based static site generators like Jekyll, Hugo, and MkDocs, providing fast and reliable link validation for documentation projects and static websites.
 
-```sh
-python -m pip install linkcheckmd
+## Features
+
+- ⚡ **Ultra-fast**: Asynchronous processing with configurable concurrency
+- 🔗 **Comprehensive**: Checks both local and remote links
+- 🎯 **Selective**: Filter by domain or exclude specific domains *(NEW in this fork)*
+- 🛡️ **Robust**: Handles SSL verification, custom headers, and retry logic
+- 📊 **Detailed**: Verbose output with timing information
+- 🚀 **CI-ready**: Perfect for continuous integration pipelines
+- 🔧 **Flexible**: Both Python API and command-line interface
+
+## Installation
+
+### Latest Release (PyPI)
+```bash
+pip install linkcheckmd
 ```
 
-or for latest development version.
-
-```sh
+### Development Version
+```bash
 git clone https://github.com/scivision/linkchecker-markdown
-
 pip install -e ./linkchecker-markdown
 ```
 
-## Usage
+## Quick Start
 
-The static site generator does NOT have to be running for these tests.
-This program looks at the Markdown .md files directly.
+### Command Line Usage
+```bash
+# Check all markdown files in current directory
+python -m linkcheckmd .
 
-If any local or remote links are determined to be missing, the following happens:
+# Check specific directory recursively
+python -m linkcheckmd -r ./docs
 
-* the file containing the bad link and the link is printed to "stdout"
-* the program will exit with code 22 instead of 0 after all files are checked
+# Exclude problematic domains
+python -m linkcheckmd -r ./docs -e example.com -e slow-site.org
 
-The bad links are printed to stdout since the normal operation of this program is to check for errors.
-Due to the fast, concurrent checking and numerous pages checked, there may be diagnostics printed to stderr.
-That way library error messages can be kept separate from the missing page locations printed on stdout.
+# Check only local files (skip remote URLs)
+python -m linkcheckmd -local ./docs
+```
 
-
-The examples assume webpage Markdown files have top-level directory ~/web.
-*If using the linkchecker on an MkDocs documentation project, Markdown files
-are typically found in a `~/docs` directory.*
-
-### Python code
-
+### Python API
 ```python
 import linkcheckmd as lc
 
-lc.check_links("~/web")
+# Basic usage
+bad_links = lc.check_links("./docs")
+
+# With domain exclusion
+bad_links = lc.check_links("./docs", exclude_domains=["example.com", "test.org"])
+
+# Local files only
+local_issues = lc.check_local("./docs", ext=".md")
 ```
 
-### Command-line
+## Command Line Arguments
 
-This program may be invoked:
+### Required Arguments
 
-```sh
-python -m linkcheckmd
+| Argument | Description | Example |
+|----------|-------------|---------|
+| `path` | Path to Markdown files | `./docs`, `~/website/content` |
+
+### Optional Arguments
+
+| Argument | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `domain` | Check only links to specific domain | None | `github.com` |
+| `-ext` | File extension to scan | `.md` | `-ext .markdown` |
+| `-m, --method` | HTTP method (get/head) | `get` | `--method head` |
+| `--headers` | Custom HTTP headers (JSON) | None | `--headers '{"User-Agent": "MyBot"}'` |
+| `-v, --verbose` | Enable verbose output | False | `-v` |
+| `--sync` | Use synchronous requests | False | `--sync` |
+| `-local` | Check only local files | False | `-local` |
+| `-r, --recurse` | Recurse subdirectories | False | `-r` |
+| `-noverify` | Skip SSL certificate verification | False | `-noverify` |
+| `-e, --exclude` | Exclude domains from checking | [] | `-e hashicorp.com -e terraform.io` |
+
+## Detailed Usage Examples
+
+### Basic Link Checking
+
+```bash
+# Check current directory
+python -m linkcheckmd .
+
+# Check specific directory
+python -m linkcheckmd ./documentation
+
+# Check with verbose output
+python -m linkcheckmd -v ./docs
 ```
 
-* Jekyll
+### Static Site Generators
 
-    ```sh
-    python -m linkcheckmd ~/web/_posts
-    ```
+```bash
+# Jekyll
+python -m linkcheckmd ~/website/_posts
 
-* Hugo
+# Hugo
+python -m linkcheckmd ~/website/content
 
-    ```sh
-    python -m linkcheckmd ~/web/content
-    ```
+# MkDocs
+python -m linkcheckmd ~/docs
 
-* MkDocs Documentation
+# GitBook
+python -m linkcheckmd ~/gitbook
+```
 
-    ```sh
-    python -m linkcheckmd ~/docs
-    ```
+### Domain Filtering
 
-The `-v` `--verbose` options prints the URLs as they are checked.
-Observe that URLs from different markdown files are interleaved, showing the asynchronous nature of this program.
+```bash
+# Check only GitHub links
+python -m linkcheckmd ./docs github.com
 
-### Benchmark
+# Exclude multiple domains
+python -m linkcheckmd -r ./docs -e hashicorp.com -e terraform.io -e slow-external-site.com
 
-For benchmarking and reference, we include a synchronous Requests-based method.
-For a website with 100+ pages, compare times of:
+# Exclude domains with subdomains
+python -m linkcheckmd ./docs -e reddit.com  # Excludes www.reddit.com, old.reddit.com, etc.
+```
 
-### Git precommit
+### Advanced Options
 
-See
-[./examples/pre-commit](./examples/pre-commit)
-script for a
-[Git hook pre-commit](https://www.scivision.dev/git-markdown-pre-commit-linkcheck)
-Python script.
+```bash
+# Use HEAD requests for faster checking (may have false positives)
+python -m linkcheckmd --method head ./docs
 
-### Tox and CI
+# Custom headers for sites requiring authentication
+python -m linkcheckmd --headers '{"Authorization": "Bearer token123"}' ./docs
 
-This program can also be used as a check for bad links during continuous integration
-testing or when using [`tox`](https://tox.readthedocs.io/).
+# Skip SSL verification for internal sites
+python -m linkcheckmd -noverify ./internal-docs
+
+# Use synchronous checking (slower but more predictable)
+python -m linkcheckmd --sync ./docs
+```
+
+### Local File Checking Only
+
+```bash
+# Check only internal links (skip all HTTP/HTTPS)
+python -m linkcheckmd -local ./docs
+
+# Useful for offline development or testing internal structure
+python -m linkcheckmd -local -r ./entire-project
+```
+
+## Domain Exclusion Feature
+
+The `-e, --exclude` option allows you to skip link checking for specific domains. This is particularly useful for:
+
+- **Known problematic sites**: Domains with anti-bot protection or rate limiting
+- **Internal services**: Private or development domains not accessible during CI
+- **Third-party dependencies**: External services outside your control
+- **Performance optimization**: Skip slow or unreliable domains
+
+### How It Works
+
+Domain exclusion performs case-insensitive substring matching:
+
+```bash
+# This command
+python -m linkcheckmd -e example.com ./docs
+
+# Will skip these URLs:
+# https://example.com/page
+# https://www.example.com/api
+# https://api.example.com/v1/data
+# http://blog.example.com/post/123
+```
+
+### CI/CD Integration Examples
+
+#### GitLab CI
+```yaml
+check-links:
+  stage: test
+  script:
+    - pip install linkcheckmd
+    - python -m linkcheckmd -r ./docs -e hashicorp.com -e terraform.io
+  rules:
+    - if: $CI_MERGE_REQUEST_IID
+```
+
+#### GitHub Actions
+```yaml
+- name: Check Links
+  run: |
+    pip install linkcheckmd
+    python -m linkcheckmd -r ./docs -e internal.company.com -e staging.example.org
+```
+
+#### Jenkins
+```groovy
+stage('Link Check') {
+    steps {
+        sh 'pip install linkcheckmd'
+        sh 'python -m linkcheckmd -r ./docs -e dev.example.com'
+    }
+}
+```
+
+## Python API Reference
+
+### Core Functions
+
+#### `check_links(path, domain=None, **kwargs)`
+Main function that checks both local and remote links.
+
+**Parameters:**
+- `path` (Path): Directory containing Markdown files
+- `domain` (str, optional): Check only links to this domain
+- `ext` (str): File extension to scan (default: ".md")
+- `hdr` (dict, optional): Custom HTTP headers
+- `method` (str): HTTP method - "get" or "head" (default: "get")
+- `use_async` (bool): Use async processing (default: True)
+- `local` (bool): Check only local files (default: False)
+- `recurse` (bool): Recurse subdirectories (default: False)
+- `ssl_verify` (bool): Verify SSL certificates (default: True)
+- `exclude_domains` (list, optional): Domains to exclude from checking
+
+**Returns:** List of bad links as tuples (file_path, url, error)
+
+#### `check_local(path, ext=".md")`
+Check only local/internal links within Markdown files.
+
+**Parameters:**
+- `path` (Path): Directory to scan
+- `ext` (str): File extension to check
+
+**Returns:** Generator of tuples (file_path, problematic_url)
+
+#### `check_remotes(path, domain=None, **kwargs)`
+Check only remote HTTP/HTTPS links.
+
+**Parameters:** Same as `check_links()` but focuses on remote URLs only.
+
+**Returns:** List of bad remote links
+
+### Example Usage
+
+```python
+import linkcheckmd as lc
+from pathlib import Path
+
+# Basic check
+docs_path = Path("./documentation")
+issues = lc.check_links(docs_path)
+
+# Advanced configuration
+issues = lc.check_links(
+    docs_path,
+    exclude_domains=["internal.company.com", "dev.example.org"],
+    method="head",  # Faster but less reliable
+    ssl_verify=False,  # For internal sites
+    recurse=True,  # Check subdirectories
+    hdr={"User-Agent": "LinkChecker/1.0"}  # Custom headers
+)
+
+# Handle results
+for file_path, url, error in issues:
+    print(f"❌ {file_path}: {url} - {error}")
+
+# Check only local links
+local_issues = list(lc.check_local(docs_path))
+for file_path, url in local_issues:
+    print(f"🔗 Local link issue in {file_path}: {url}")
+```
+
+## Exit Codes
+
+LinkCheckMD follows standard Unix conventions:
+
+- **0**: Success - all links are valid
+- **22**: Error - one or more links are broken (follows cURL convention)
+
+This makes it perfect for CI/CD pipelines where you want builds to fail on broken links.
+
+## Performance and Behavior
+
+### Asynchronous Processing
+- Uses `aiohttp` for concurrent HTTP requests
+- Configurable timeout (10 seconds default)
+- Automatic retry logic for transient failures
+- Memory-efficient streaming for large sites
+
+### Error Handling
+- Distinguishes between network errors and HTTP errors
+- Handles redirects automatically
+- Graceful handling of SSL certificate issues
+- Comprehensive logging with `-v` flag
+
+### Output Format
+- **stdout**: Broken links (for easy parsing)
+- **stderr**: Debug information and warnings
+- **Timing**: Execution time printed at completion
+
+## Common Use Cases
+
+### Documentation Teams
+```bash
+# Daily documentation health check
+python -m linkcheckmd -r ./docs -e internal.company.com > broken-links.txt
+```
+
+### DevOps Integration
+```bash
+# Pre-deployment link validation
+python -m linkcheckmd -r ./site-content -e staging.example.com -e dev.example.com
+```
+
+### Content Migration
+```bash
+# Check content after migration, excluding old domains
+python -m linkcheckmd ./migrated-content -e old-site.com -e legacy.example.org
+```
+
+### Development Workflow
+```bash
+# Quick local check during development
+python -m linkcheckmd -local ./docs  # Skip external links
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**False Positives with HEAD Requests:**
+```bash
+# Solution: Use GET method (slower but more reliable)
+python -m linkcheckmd --method get ./docs
+```
+
+**SSL Certificate Errors:**
+```bash
+# Solution: Disable SSL verification
+python -m linkcheckmd -noverify ./docs
+```
+
+**Rate Limiting:**
+```bash
+# Solution: Exclude problematic domains
+python -m linkcheckmd -e rate-limited-site.com ./docs
+```
+
+**Slow External Sites:**
+```bash
+# Solution: Use domain exclusion
+python -m linkcheckmd -e slow-site.org -e another-slow-site.com ./docs
+```
+
+### Debugging
+
+Enable verbose output to see what's happening:
+```bash
+python -m linkcheckmd -v ./docs
+```
+
+This shows:
+- URLs being checked in real-time
+- Success confirmations
+- Detailed error messages
+- Performance timing
 
 ## Alternatives
 
-Strict anti-leeching methods can cause false positives with this and other link checking programs.
+While LinkCheckMD is optimized for Markdown files, consider these alternatives for different use cases:
 
-Alternative solutions include:
+- **[htmltest](https://github.com/wjdp/htmltest)**: Go-based, works with HTML files
+- **[GitHub Action](https://github.com/marketplace/actions/markdown-link-check)**: For GitHub-hosted projects
+- **[Netlify Plugin](https://github.com/munter/netlify-plugin-checklinks)**: For Netlify deployments
+- **Browser-based tools**: For JavaScript-heavy sites requiring full rendering
 
-* asyncio-based web browser interface like Arsenic
-* Go-based [htmltest](https://github.com/wjdp/htmltest).
-* [GitHub Action](https://github.com/marketplace/actions/markdown-link-check) for checking links in Markdown files.
-* Netlify link-check [plugin](https://github.com/munter/netlify-plugin-checklinks#readme)
-* LinkChecker.py: too many false positives/negatives, very slow and only works with HTML.
+## Contributing
+
+This fork adds domain exclusion functionality to the original [scivision/linkchecker-markdown](https://github.com/scivision/linkchecker-markdown) project. 
+
+For contributions to the core functionality, please consider contributing to the upstream project. For issues or improvements specific to the domain exclusion feature, contributions are welcome!
+
+Areas for improvement:
+
+- Additional output formats (JSON, XML)
+- Better regex patterns for edge cases
+- Performance optimizations
+- Additional authentication methods
+- Support for more file formats
+
+## Credits
+
+- **Original Project**: [scivision/linkchecker-markdown](https://github.com/scivision/linkchecker-markdown)
+- **Domain Exclusion Feature**: Added in this fork for CI/CD workflows that need to skip specific domains
+
+## License
+
+See [LICENSE.txt](LICENSE.txt) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "linkcheckmdmd"
+name = "linkcheckmd"
 description = "Check links for Markdown-based site"
 keywords = ["hugo", "jekyll", "markdown", "linkcheck"]
 classifiers = ["Development Status :: 5 - Production/Stable",

--- a/src/linkcheckmd/__main__.py
+++ b/src/linkcheckmd/__main__.py
@@ -38,6 +38,9 @@ def main():
         "-r", "--recurse", help="recurse directories under path", action="store_true"
     )
     p.add_argument("-noverify", help="don't verify SSL certificates", action="store_true")
+    p.add_argument(
+        "-e", "--exclude", help="exclude domains from checking", action="append", default=[]
+    )
     P = p.parse_args()
 
     if P.verbose:
@@ -54,6 +57,7 @@ def main():
         local=P.local,
         recurse=P.recurse,
         ssl_verify=not P.noverify,
+        exclude_domains=P.exclude,
     )
 
     print(f"{time.monotonic() - tic:0.3} seconds to check links")

--- a/src/linkcheckmd/base.py
+++ b/src/linkcheckmd/base.py
@@ -23,6 +23,7 @@ def check_links(
     local: bool = False,
     recurse: bool = False,
     ssl_verify: bool = True,
+    exclude_domains: list[str] | None = None,
 ) -> T.Iterable[tuple] | None:
 
     if local and recurse:
@@ -43,6 +44,7 @@ def check_links(
             use_async=use_async,
             recurse=recurse,
             ssl_verify=ssl_verify,
+            exclude_domains=exclude_domains,
         )
 
     return bad
@@ -95,6 +97,7 @@ def check_remotes(
     use_async: bool = True,
     recurse: bool = False,
     ssl_verify: bool = True,
+    exclude_domains: list[str] | None = None,
 ) -> list[tuple[Path, str, T.Any]]:
     if domain:
         pat = "https?://" + domain + r"[=a-zA-Z0-9\_\/\?\&\%\+\#\.\-]*"
@@ -120,13 +123,14 @@ def check_remotes(
                 method=method,
                 recurse=recurse,
                 ssl_verify=ssl_verify,
+                exclude_domains=exclude_domains,
             )
         )
     else:
         from .sync import check_urls as sync_urls
 
         urls = sync_urls(
-            path, regex=pat, ext=ext, hdr=hdr, recurse=recurse, ssl_verify=ssl_verify
+            path, regex=pat, ext=ext, hdr=hdr, recurse=recurse, ssl_verify=ssl_verify, exclude_domains=exclude_domains
         )
 
     return urls

--- a/src/linkcheckmd/coro.py
+++ b/src/linkcheckmd/coro.py
@@ -29,12 +29,13 @@ async def check_urls(
     method: str = "get",
     recurse: bool = False,
     ssl_verify: bool = True,
+    exclude_domains: list[str] | None = None,
 ) -> list[tuple[Path, str, T.Any]]:
 
     glob = re.compile(regex)
 
     tasks = [
-        check_url(fn, glob, ext, hdr, method=method, ssl_verify=ssl_verify)
+        check_url(fn, glob, ext, hdr, method=method, ssl_verify=ssl_verify, exclude_domains=exclude_domains)
         for fn in files.get(path, ext, recurse)
     ]
 
@@ -59,6 +60,7 @@ async def check_url(
     *,
     method: str = "get",
     ssl_verify: bool = True,
+    exclude_domains: list[str] | None = None,
 ) -> list[tuple[Path, str, T.Any]]:
 
     urls = glob.findall(fn.read_text(errors="ignore"))
@@ -70,6 +72,16 @@ async def check_url(
     for url in urls:
         if ext == ".md":
             url = url[1:-1]
+        
+        # Skip URLs that contain excluded domains
+        if exclude_domains:
+            should_skip = False
+            for domain in exclude_domains:
+                if domain.lower() in url.lower():
+                    should_skip = True
+                    break
+            if should_skip:
+                continue
         try:
             # anti-crawling behavior doesn't like .head() method--.get() is slower but avoids lots of false positives
             async with aiohttp.ClientSession(

--- a/src/linkcheckmd/sync.py
+++ b/src/linkcheckmd/sync.py
@@ -30,6 +30,7 @@ def check_urls(
     hdr: dict[str, str] | None = None,
     ssl_verify: bool = False,
     recurse: bool = False,
+    exclude_domains: list[str] | None = None,
 ) -> list[tuple[Path, str, T.Any]]:
 
     bads: list[tuple[Path, str, T.Any]] = []
@@ -44,7 +45,7 @@ def check_urls(
             sess.max_redirects = 5
         # %% loop
         for fn in files.get(path, ext, recurse):
-            for bad in check_url(fn, glob, ext, sess, hdr, ssl_verify):
+            for bad in check_url(fn, glob, ext, sess, hdr, ssl_verify, exclude_domains):
                 print("\n", bad[0], bad[1], bad[2])
                 bads.append(bad)
 
@@ -60,6 +61,7 @@ def check_url(
     sess,
     hdr: dict[str, str] | None = None,
     ssl_verify: bool = False,
+    exclude_domains: list[str] | None = None,
 ) -> T.Iterable[tuple[Path, str, T.Any]]:
 
     urls = glob.findall(fn.read_text(errors="ignore"))
@@ -67,6 +69,16 @@ def check_url(
     for url in urls:
         if ext == ".md":
             url = url[1:-1]
+        
+        # Skip URLs that contain excluded domains
+        if exclude_domains:
+            should_skip = False
+            for domain in exclude_domains:
+                if domain.lower() in url.lower():
+                    should_skip = True
+                    break
+            if should_skip:
+                continue
         try:
             R = sess.head(url, allow_redirects=True, timeout=TIMEOUT, verify=ssl_verify)
             if R.status_code in RETRYCODES:


### PR DESCRIPTION
* Exclude domains from checking

```sh
python -m linkcheckmd -r ./docs -e example.com -e slow-site.org
```

The `-e, --exclude` option allows specifying one or more domains to exclude from link checking. This is useful to skip known problematic sites, internal services, or slow external domains. Multiple `-e` options can be used to build the exclusion list.

Observe that URLs from different markdown files are interleaved, showing the asynchronous nature of this program.

```markdown
# Example usage excluding domains:
python -m linkcheckmd -r ./docs -e hashicorp.com -e terraform.io -e slow-external-site.com
```